### PR TITLE
Fix set property error of undefined

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -244,7 +244,6 @@ export default class SumoLogicMetricsDatasource {
         if (response.status === 'error') {
           throw response.error;
         }
-        const target = targets[i];
         result = self.transformMetricData(targets, response.data.response);
       }
 
@@ -325,7 +324,6 @@ export default class SumoLogicMetricsDatasource {
         console.log("sumo-logic-metrics-datasource - Datasource.transformMetricData - error: " +
           JSON.stringify(response));
         errors.push(response.message);
-        target.error = response.message;
       }
     }
 


### PR DESCRIPTION
This error occured, when Sumo API returned error or warning in
results list, eg. "Too many time series matched ...".
Variable `target` was `undefined`, because `targets.length < response.length`.
Equal lenght of both arrays is not guaranteed by the Sumo API.

The error message is saved in `errors` array and will be thrown later,
so there is no need to provide additional error handling or saving the error
with target.

Deleted also unused variable `target`.